### PR TITLE
ci: use default token to lint pull request title

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: amannn/action-semantic-pull-request@v5.0.2
         env:
-          GITHUB_TOKEN: ${{ secrets.LINT_PR_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           types: |
             build


### PR DESCRIPTION
... this way we do not need a separate token and simplify the repository setup.