### PR TITLE
feat: add default templates valid for all projects

### DIFF
--- a/.config/cspell.json
+++ b/.config/cspell.json
@@ -1,7 +1,7 @@
 {
   "version": "0.2",
   "language": "en",
-  "words": ["cpus"],
+  "words": ["cpus", "Hapag"],
   "ignoreWords": [
     "amannn",
     "codeowners",

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ runs very fast.
 
 Release management is done with [release-please](https://github.com/googleapis/release-please). All PRs are merged into
 main and the release tool automatically created a new PR with a changelog. As soon as this PR is merged, the release
-is tagged and published on GitHub. 
+is tagged and published on GitHub.
 
 For updating the dependencies automatically we provide a [Renovate](https://docs.renovatebot.com/) configuration file.
 Renovate automatically proposes a PR if a dependency is out of date.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # Repository-Templates
 
 This repository stores templates used to setup new repositories. The templates are stored in `templates/`.
+
+## Default Templates
+
+Stored in `templates/default` and added to every new project. Contains a set of linters, release management, ChatOps
+tools and a welcome message for contributors as well as a contribution guideline.
+
+To ensure a high quality of committed files, a [pre-commit](https://pre-commit.com/) configuration is also provided and
+can be installed with `pre-commit install`. The default configuration detects the most common errors in the code and
+runs very fast.
+
+Release management is done with [release-please](https://github.com/googleapis/release-please). All PRs are merged into
+main and the release tool automatically created a new PR with a changelog. As soon as this PR is merged, the release
+is tagged and published on GitHub. 
+
+For updating the dependencies automatically we provide a [Renovate](https://docs.renovatebot.com/) configuration file.
+Renovate automatically proposes a PR if a dependency is out of date.

--- a/templates/default/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/templates/default/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Found a bug? Report it!
+title: ''
+labels: new, bug
+assignees: ''
+---
+
+<!-- Before submitting a bug, make sure that you meet the following requirements:
+  1. use the latest version of the module
+  2. read the documentation
+-->
+
+# Describe the bug
+
+A clear and concise description of what the bug is.
+
+# To Reproduce
+
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+# Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+# Additional context
+
+Add any other context about the problem here.

--- a/templates/default/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/templates/default/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,39 @@
+---
+name: Feature Request
+about: Propose a new feature
+title: ''
+labels: new, enhancement
+assignees: ''
+---
+
+# Describe the solution you'd like
+
+<!--
+  Provide a clear and concise description of what you want to happen. Add some sentences to describe the use case
+  to be solved by this feature.
+-->
+
+# Describe alternatives you've considered
+
+<!--
+  Let us know about other solutions you've tried or researched.
+-->
+
+# Suggest a solution
+
+<!--
+Things to include:
+
+- details of the technical implementation
+- tradeoffs made in design decisions
+ -caveats and considerations for the future
+
+If there are multiple solutions, please present each one separately. Save comparisons for the very end.
+-->
+
+# Additional context
+
+<!--
+  Is there anything else you can add about the proposal?
+  You might want to link to related issues here, if you haven't already.
+-->

--- a/templates/default/.github/pull_request_template.md
+++ b/templates/default/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+# Description
+
+What is the overall goal of your PR? Which problem does it solve? Please also include relevant motivation and context.
+List any dependencies that are required for this change.
+
+Fixes #(issue number)
+
+# Migrations required
+
+yes: please describe the migration
+no: please delete the whole paragraph
+
+# Verification
+
+Please describe the test cases you used to verify your code. Did you check the change in your environment?
+
+# Checklist
+
+- [ ] My code follows the style guidelines of the project
+- [ ] I have performed a self-review of my own code
+- [ ] I have made corresponding changes to the documentation

--- a/templates/default/.github/workflows/linter.yml
+++ b/templates/default/.github/workflows/linter.yml
@@ -1,0 +1,100 @@
+---
+name: Lint files
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+
+jobs:
+  find-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/paths-filter@v2.11.1
+        id: changes
+        with:
+          filters: |
+            json:
+              - '**/*.json'
+
+            markdown:
+              - '**/*.md'
+
+            renovate-config:
+              - 'renovate.json'
+              - 'default.json'
+
+            workflow:
+              - '.github/workflows/*.yml'
+              - '.github/workflows/*.yaml'
+
+            yaml:
+              - '**/*.yaml'
+              - '**/*.yml'
+    outputs:
+      json: ${{ steps.changes.outputs.json }}
+      markdown: ${{ steps.changes.outputs.markdown }}
+      renovate-config: ${{ steps.changes.outputs.renovate-config }}
+      workflow: ${{ steps.changes.outputs.workflow }}
+      yaml: ${{ steps.changes.outputs.yaml }}
+
+  lint-json:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    if: needs.find-changes.outputs.json == 'true'
+    needs: find-changes
+    steps:
+      - uses: actions/checkout@v3.3.0
+
+      - name: Run JSON Lint
+        run: bash <(curl -s https://raw.githubusercontent.com/CICDToolbox/json-lint/master/pipeline.sh)
+
+  lint-markdown:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    if: needs.find-changes.outputs.markdown == 'true'
+    needs: find-changes
+    steps:
+      - uses: actions/checkout@v3.3.0
+
+      - name: Validate Markdown file
+        run: |
+          npm install -g markdownlint-cli
+          markdownlint -c .config/markdownlint.yml -i CHANGELOG.md "**/*.md"
+
+  lint-renovate:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    if: needs.find-changes.outputs.renovate-config == 'true'
+    needs: find-changes
+    steps:
+      - uses: actions/checkout@v3.3.0
+
+      - uses: suzuki-shunsuke/github-action-renovate-config-validator@v0.1.2
+
+  lint-workflow:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: find-changes
+    if: needs.find-changes.outputs.workflow == 'true'
+    container:
+      image: rhysd/actionlint:1.6.22@sha256:5f957b2a08d223e48133e1a914ed046bea12e578fe2f6ae4de47fdbe691a2468
+      options: --cpus 1 --user root
+    steps:
+      - uses: actions/checkout@v3.3.0
+      - name: Validate Github workflows
+        run: |
+          mkdir .git
+          actionlint -color
+
+  lint-yaml:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: find-changes
+    if: needs.find-changes.outputs.yaml == 'true'
+    steps:
+      - uses: actions/checkout@v3.3.0
+      - name: yaml-lint
+        uses: ibiqlik/action-yamllint@v3.1.1
+        with:
+          config_file: .config/yamllint.yml
+          strict: true

--- a/templates/default/.github/workflows/pull-request.yml
+++ b/templates/default/.github/workflows/pull-request.yml
@@ -1,0 +1,49 @@
+---
+name: "Pull Request"
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+    branches-ignore:
+      - "release-please--branches--*"
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+          # Configure which scopes are allowed.
+          # deps - dependency updates
+          # main - for release-please (scope used for releases)
+          scopes: |
+            deps
+            main
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+          wip: true
+          validateSingleCommit: false
+          validateSingleCommitMatchesPrTitle: false

--- a/templates/default/.github/workflows/release.yml
+++ b/templates/default/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+---
+name: Create a release
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release
+        uses: google-github-actions/release-please-action@v3.7.3
+        with:
+          release-type: simple
+          signoff: "Matthias Kay <matthias.kay@hlag.com>"

--- a/templates/default/.github/workflows/slash-ops-command-help.yml
+++ b/templates/default/.github/workflows/slash-ops-command-help.yml
@@ -1,0 +1,35 @@
+---
+name: Execute ChatOps command
+
+# yamllint disable-line rule:truthy
+on:
+  repository_dispatch:
+    types:
+      - help-command
+
+jobs:
+  help-command:
+    name: "ChatOps: /help"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.3.0
+
+      - name: Choose maintainer
+        id: vars
+        run: |
+          maintainer=$(grep -oE "@[a-zA-Z0-9_-]+" CODEOWNERS | shuf -n 1)
+          echo "maintainer=$maintainer" >> "$GITHUB_OUTPUT"
+
+      - name: Create comment
+        uses: actions/github-script@v6.4.0
+        with:
+          # yamllint disable rule:line-length
+          script: |
+            // adds a comment to the PR (there is the issue API, which works work PRs too)
+            github.rest.issues.createComment({
+              issue_number: context.payload.client_payload.github.payload.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Hey there ${{ steps.vars.outputs.maintainer }}, could you please help @${{ github.event.client_payload.github.payload.comment.user.login }} out?'
+            })
+          # yamllint enable rule:line-length

--- a/templates/default/.github/workflows/slash-ops-comment-dispatch.yml
+++ b/templates/default/.github/workflows/slash-ops-comment-dispatch.yml
@@ -1,0 +1,21 @@
+---
+name: PR commented
+
+# yamllint disable-line rule:truthy
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  slash-command-dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v3.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-type: pull-request
+          reactions: true
+          commands: |
+            help

--- a/templates/default/.github/workflows/spelling.yml
+++ b/templates/default/.github/workflows/spelling.yml
@@ -1,0 +1,16 @@
+---
+name: 'Check spelling'
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+
+jobs:
+  cspell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.3.0
+
+      - uses: streetsidesoftware/cspell-action@v2.19.0
+        with:
+          config: .config/cspell.json

--- a/templates/default/.github/workflows/welcome-message.yml
+++ b/templates/default/.github/workflows/welcome-message.yml
@@ -1,0 +1,27 @@
+---
+name: PR opened
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  add-welcome-message:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v6.4.0
+        with:
+          # yamllint disable rule:line-length
+          script: |
+            // adds a comment to the PR (there is the issue API only which works work PRs too)
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Hey @${{ github.event.pull_request.user.login }}! 👋\n\nThank you for your contribution to the project. Please refer to the [contribution rules](../blob/main/CONTRIBUTING.md) for a quick overview of the process.\n\nMake sure that this PR clearly explains:\n\n- the problem being solved\n- the best way a reviewer and you can test your changes\n\nWith submitting this PR you confirm that you hold the rights of the code added and agree that it will published under this [LICENSE](../blob/main/LICENSE).\n\nThe following ChatOps commands are supported:\n- `/help`: notifies a maintainer to help you out\n\nSimply add a comment with the command in the first line. If you need to pass more information, separate it with a blank line from the command.\n\n_This message was generated automatically. You are welcome to [improve it](../blob/main/.github/workflows/welcome-message.yml)._'
+            })
+          # yamllint enable rule:line-length

--- a/templates/default/.pre-commit-config.yaml
+++ b/templates/default/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: fix-byte-order-marker
+      - id: check-added-large-files
+        args:
+          - "--maxkb=20"
+      - id: check-case-conflict
+      - id: check-yaml
+      - id: check-json
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+      - id: check-merge-conflict
+      - id: check-shebang-scripts-are-executable
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.6.0
+    hooks:
+      - id: prettier

--- a/templates/default/CODEOWNERS
+++ b/templates/default/CODEOWNERS
@@ -1,0 +1,2 @@
+# license file shouldn't be changed and needs to be reviewed by lawyers
+LICENSE @kayman-mk

--- a/templates/default/CONTRIBUTING.md
+++ b/templates/default/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contribution guide
+
+We appreciate your thought to contribute to open source. :heart: We want to make contributing as easy as possible. You are welcome to:
+
+- Report a bug
+- Discuss the current state of the code
+- Submit a fix
+- Propose new features
+
+We use [Github Flow](https://guides.github.com/introduction/flow/index.html), so all code changes happen through pull
+requests. We actively welcome your pull requests:
+
+1. Fork the repo and create your branch from `main`.
+2. If you've added code, check one of the examples.
+3. Make sure your code lints.
+4. Raise a pull request.
+
+## Documentation
+
+We use [pre-commit](https://pre-commit.com/) for some default checks which are fast and find the most common errors.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the license available at
+[LICENSE](blob/main/LICENSE).

--- a/templates/default/renovate.json
+++ b/templates/default/renovate.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["github>Hapag-Lloyd/Renovate-Global-Configuration"]
+}


### PR DESCRIPTION
# Description

Adds 

- `pre-commit` configuration
- welcome message for new PRs
- `/help` command
- `release-please` to control the release process and `CHANGELOG.md` generation
- linter for all file types
- spell checker
- linter for PR titles as they are used to determine the next version number automatically
- Renovate configuration for automatic dependency updates

# Verification

Not done, templates only.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
