### PR TITLE
feat: add workflow for Terraform modules

### DIFF
--- a/.config/cspell.json
+++ b/.config/cspell.json
@@ -1,15 +1,20 @@
 {
   "version": "0.2",
   "language": "en",
-  "words": ["cpus", "Hapag"],
+  "words": ["cpus", "Hapag", "Infracost", "oidc", "tflint", "tfsec"],
   "ignoreWords": [
     "amannn",
     "codeowners",
+    "codeql",
+    "datasource",
     "dorny",
     "ibiqlik",
     "kayman",
+    "ludeeus",
     "markdownlint",
     "rhysd",
+    "ruleset",
+    "sarif",
     "shuf",
     "shunsuke",
     "signoff"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Renovate automatically proposes a PR if a dependency is out of date.
 The templates are stored in `templates/terraform-module`.
 
 A Terraform module should at least provide 3 examples
+
 1. `examples/cost`: for infrastructure cost calculation
 2. `examples/simple`: for a quick and easy demonstration
 3. `examples/full`: for a full blown example
@@ -31,5 +32,6 @@ So far it runs a `terraform validate` for all examples and the Terraform minimum
 and the latest Terraform version.
 
 Planned:
-  - integrate TfLint
-  - integrate Infracost
+
+- integrate TfLint
+- integrate Infracost

--- a/README.md
+++ b/README.md
@@ -17,3 +17,19 @@ is tagged and published on GitHub.
 
 For updating the dependencies automatically we provide a [Renovate](https://docs.renovatebot.com/) configuration file.
 Renovate automatically proposes a PR if a dependency is out of date.
+
+## Terraform Module Templates
+
+The templates are stored in `templates/terraform-module`.
+
+A Terraform module should at least provide 3 examples
+1. `examples/cost`: for infrastructure cost calculation
+2. `examples/simple`: for a quick and easy demonstration
+3. `examples/full`: for a full blown example
+
+So far it runs a `terraform validate` for all examples and the Terraform minimum version (insert in the workflow file!)
+and the latest Terraform version.
+
+Planned:
+  - integrate TfLint
+  - integrate Infracost

--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ and the latest Terraform version.
 
 Planned:
 
-- integrate TfLint
+- integrate TfLintt
 - integrate Infracost

--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ and the latest Terraform version.
 
 Planned:
 
-- integrate TfLintt
+- integrate TfLint
 - integrate Infracost

--- a/templates/default/.config/cspell.json
+++ b/templates/default/.config/cspell.json
@@ -1,0 +1,22 @@
+{
+  "version": "0.2",
+  "language": "en",
+  "words": ["cpus", "Hapag", "Infracost", "oidc", "tflint", "tfsec"],
+  "ignoreWords": [
+    "amannn",
+    "codeowners",
+    "codeql",
+    "datasource",
+    "dorny",
+    "ibiqlik",
+    "kayman",
+    "ludeeus",
+    "markdownlint",
+    "rhysd",
+    "ruleset",
+    "sarif",
+    "shuf",
+    "shunsuke",
+    "signoff"
+  ]
+}

--- a/templates/default/.github/workflows/linter.yml
+++ b/templates/default/.github/workflows/linter.yml
@@ -71,6 +71,15 @@ jobs:
 
       - uses: suzuki-shunsuke/github-action-renovate-config-validator@v0.1.2
 
+  lint-shell:
+    name: Check shell scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.3.0
+
+      - name: ShellCheck
+        uses: ludeeus/action-shellcheck@2.0.0
+
   lint-workflow:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/templates/terraform-module/.config/tflint.hcl
+++ b/templates/terraform-module/.config/tflint.hcl
@@ -1,0 +1,19 @@
+config {
+  force               = false
+  disabled_by_default = false
+}
+
+plugin "terraform" {
+  enabled = true
+  preset  = "all"
+}
+
+plugin "aws" {
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+  # renovate: datasource=github-tags depName=terraform-linters/tflint-ruleset-aws
+  version = "0.21.2"
+
+  enabled    = true
+  deep_check = true
+  region     = "eu-central-1"
+}

--- a/templates/terraform-module/.github/workflows/terraform-tfsec.yml
+++ b/templates/terraform-module/.github/workflows/terraform-tfsec.yml
@@ -5,7 +5,7 @@ name: TfSec
 on:
   pull_request:
   schedule:
-    - cron: '47 3 * * 1'
+    - cron: "47 3 * * 1"
 
 jobs:
   tfsec:

--- a/templates/terraform-module/.github/workflows/terraform-tfsec.yml
+++ b/templates/terraform-module/.github/workflows/terraform-tfsec.yml
@@ -1,0 +1,32 @@
+---
+name: TfSec
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+  schedule:
+    - cron: '47 3 * * 1'
+
+jobs:
+  tfsec:
+    name: Run tfsec sarif report
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v3.3.0
+
+      - name: Run tfsec
+        uses: tfsec/tfsec-sarif-action@v0.1.4
+        with:
+          sarif_file: tfsec.sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v2.12.2
+        with:
+          # Path to SARIF file relative to the root of the repository
+          sarif_file: tfsec.sarif

--- a/templates/terraform-module/.github/workflows/terraform.yml
+++ b/templates/terraform-module/.github/workflows/terraform.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Init TFLint
         run: tflint --config=.config/tflint.hcl --init
 
-    # needs OIDC setup for credentials
-    # https://github.com/aws-actions/configure-aws-credentials
-    # - name: Run TFLint
-    #   run: tflint --config=.config/tflint.hcl -f compact
+      # needs OIDC setup for credentials
+      # https://github.com/aws-actions/configure-aws-credentials
+      # - name: Run TFLint
+      #   run: tflint --config=.config/tflint.hcl -f compact

--- a/templates/terraform-module/.github/workflows/terraform.yml
+++ b/templates/terraform-module/.github/workflows/terraform.yml
@@ -1,0 +1,54 @@
+---
+name: Terraform
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        terraform: [1.0.0, latest]
+        directories: [".", "examples/cost", "examples/simple", "examples/full"]
+    defaults:
+      run:
+        working-directory: ${{ matrix.directories }}
+    steps:
+      - uses: actions/checkout@v3.3.0
+
+      - uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ matrix.terraform }}
+
+      - run: terraform -version
+
+      - run: terraform init -input=false -backend=false
+
+      - run: terraform validate
+
+  tflint:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/terraform-linters/tflint:v0.44.1@sha256:d7a49b9287c5d47566e664431ccfb2d7769bb8dc3bf544fa0145e6ba1479d153
+    steps:
+      - uses: actions/checkout@v3.3.0
+
+      - uses: actions/cache@v3.2.5
+        name: Cache plugin dir
+        with:
+          path: ~/.tflint.d/plugins
+          key: tflint-${{ hashFiles('.config/tflint.hcl') }}
+
+      - name: Show version
+        run: tflint --config=.config/tflint.hcl --version
+
+      - name: Init TFLint
+        run: tflint --config=.config/tflint.hcl --init
+
+      #needs OIDC setup for credentials
+      #https://github.com/aws-actions/configure-aws-credentials
+      #- name: Run TFLint
+      #  run: tflint --config=.config/tflint.hcl -f compact

--- a/templates/terraform-module/.github/workflows/terraform.yml
+++ b/templates/terraform-module/.github/workflows/terraform.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Init TFLint
         run: tflint --config=.config/tflint.hcl --init
 
-      # needs OIDC setup for credentials
-      # https://github.com/aws-actions/configure-aws-credentials
-      # - name: Run TFLint
-      #   run: tflint --config=.config/tflint.hcl -f compact
+        # needs OIDC setup for credentials
+        # https://github.com/aws-actions/configure-aws-credentials
+        # - name: Run TFLint
+        #   run: tflint --config=.config/tflint.hcl -f compact

--- a/templates/terraform-module/.github/workflows/terraform.yml
+++ b/templates/terraform-module/.github/workflows/terraform.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Init TFLint
         run: tflint --config=.config/tflint.hcl --init
 
-      #needs OIDC setup for credentials
-      #https://github.com/aws-actions/configure-aws-credentials
-      #- name: Run TFLint
-      #  run: tflint --config=.config/tflint.hcl -f compact
+    # needs OIDC setup for credentials
+    # https://github.com/aws-actions/configure-aws-credentials
+    # - name: Run TFLint
+    #   run: tflint --config=.config/tflint.hcl -f compact


### PR DESCRIPTION
# Description

Adds a standard workflow for Terraform modules. These modules should have the following examples ready:
- `examples/cost`: used to calculate the infrastructure costs if this module is used
- `examples/simple`: a quick setup of the module showing the necessary values only
- `examples/full`: a full blown example

So far the workflow starts a `terraform validate` for the minimum Terraform version required by this module (setup manually) and the latest Terraform version.

# Verification

Workflow tested in separate project

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
