### PR TITLE
feat: add TfLint to Terraform module workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ A Terraform module should at least provide 3 examples
 2. `examples/simple`: for a quick and easy demonstration
 3. `examples/full`: for a full blown example
 
-So far it runs a `terraform validate` for all examples and the Terraform minimum version (insert in the workflow file!)
+It runs a `terraform validate` for all examples and the Terraform minimum version (insert in the workflow file!)
 and the latest Terraform version.
 
-Planned:
+In addition `tflint` is also executed.
 
-- integrate TfLint
+## Planned:
+
 - integrate Infracost

--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ and the latest Terraform version.
 
 In addition `tflint` is also executed.
 
-## Planned:
+## Planned
 
 - integrate Infracost

--- a/templates/terraform-module/.github/workflows/terraform-tfsec.yml
+++ b/templates/terraform-module/.github/workflows/terraform-tfsec.yml
@@ -26,7 +26,7 @@ jobs:
           sarif_file: tfsec.sarif
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2.12.2
+        uses: github/codeql-action/upload-sarif@v2.2.3
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: tfsec.sarif

--- a/templates/terraform-module/.github/workflows/terraform.yml
+++ b/templates/terraform-module/.github/workflows/terraform.yml
@@ -6,8 +6,8 @@ on:
   pull_request:
 
 permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read # This is required for actions/checkout
+  id-token: write
+  contents: read
 
 jobs:
   validate:
@@ -56,7 +56,8 @@ jobs:
           # renovate: datasource=github-tags depName=terraform-linters/tflint
           tflint_version="0.44.1"
 
-          curl -o tflint.zip -L https://github.com/terraform-linters/tflint/releases/download/v${tflint_version}/tflint_linux_amd64.zip
+          curl -o tflint.zip -L \
+            https://github.com/terraform-linters/tflint/releases/download/v${tflint_version}/tflint_linux_amd64.zip
           unzip tflint.zip
 
       - name: Show version

--- a/templates/terraform-module/.github/workflows/terraform.yml
+++ b/templates/terraform-module/.github/workflows/terraform.yml
@@ -5,6 +5,10 @@ name: Terraform
 on:
   pull_request:
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -31,8 +35,6 @@ jobs:
 
   tflint:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/terraform-linters/tflint:v0.44.1@sha256:d7a49b9287c5d47566e664431ccfb2d7769bb8dc3bf544fa0145e6ba1479d153
     steps:
       - uses: actions/checkout@v3.3.0
 
@@ -42,13 +44,26 @@ jobs:
           path: ~/.tflint.d/plugins
           key: tflint-${{ hashFiles('.config/tflint.hcl') }}
 
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1.7.0
+        with:
+          role-to-assume: ${{ secrets.AWS_TFLINT_ROLE_ARN }}
+          role-session-name: tflint
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: install tflint
+        run: |
+          # renovate: datasource=github-tags depName=terraform-linters/tflint
+          tflint_version="0.44.1"
+
+          curl -o tflint.zip -L https://github.com/terraform-linters/tflint/releases/download/v${tflint_version}/tflint_linux_amd64.zip
+          unzip tflint.zip
+
       - name: Show version
-        run: tflint --config=.config/tflint.hcl --version
+        run: ./tflint --config=.config/tflint.hcl --version
 
       - name: Init TFLint
-        run: tflint --config=.config/tflint.hcl --init
+        run: ./tflint --config=.config/tflint.hcl --init
 
-        # needs OIDC setup for credentials
-        # https://github.com/aws-actions/configure-aws-credentials
-        # - name: Run TFLint
-        #   run: tflint --config=.config/tflint.hcl -f compact
+      - name: Run TFLint
+        run: ./tflint --config=.config/tflint.hcl -f compact


### PR DESCRIPTION
# Description

Adds the TfLint check to the Terraform module workflow. As this needs access to a cloud account, some configuration had to be done in our internal repository which setups the AWS account.

Needs a secret called `AWS_TFLINT_ROLE_ARN=aws-tflint-role-arn` and a variable `AWS_REGION=eu-central-1` in the repository.

# Verification

Tested in the bastion host project.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
