### PR TITLE
feat: add stale workflow for issues and PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository stores templates used to setup new repositories. The templates a
 ## Default Templates
 
 Stored in `templates/default` and added to every new project. Contains a set of linters, release management, ChatOps
-tools and a welcome message for contributors as well as a contribution guideline.
+tools, stale issue and PR management and a welcome message for contributors as well as a contribution guideline.
 
 To ensure a high quality of committed files, a [pre-commit](https://pre-commit.com/) configuration is also provided and
 can be installed with `pre-commit install`. The default configuration detects the most common errors in the code and

--- a/templates/default/.github/workflows/stale.yml
+++ b/templates/default/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: 'Close stale issues and PRs'
+
+on:
+  schedule:
+    - cron: '25 2 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v7.0.0
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 10 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+          days-before-stale: 30
+          days-before-close: 10
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'

--- a/templates/default/.github/workflows/stale.yml
+++ b/templates/default/.github/workflows/stale.yml
@@ -1,5 +1,7 @@
+---
 name: 'Close stale issues and PRs'
 
+# yamllint disable-line rule:truthy
 on:
   schedule:
     - cron: '25 2 * * *'
@@ -10,10 +12,12 @@ jobs:
     steps:
       - uses: actions/stale@v7.0.0
         with:
+          # yamllint disable rule:line-length
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 10 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+          # yamllint enable rule:line-length
           days-before-stale: 30
           days-before-close: 10
           stale-issue-label: 'stale'


### PR DESCRIPTION
# Description

Adds a workflow to mark issues and PRs stale after 30 days of inactivity and closes them 10 days later. Every activity will remove the `stale` label.

# Verification

None, already running in other projects.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
