### PR TITLE
fix: allow release process to create protected tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+permissions:
+  # to create protected tags
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/templates/default/.github/workflows/release.yml
+++ b/templates/default/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+permissions:
+  # to create protected tags
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

Add permission `content: write` to the `GITHUB_TOKEN` to allow Release-Please to create the release tag, which should be protected by default.

# Verification

None.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
