### PR TITLE
fix: use PAT for Release-Please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,6 @@ on:
     branches:
       - main
 
-permissions:
-  # to create protected tags
-  contents: write
-  pull-requests: write
-
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -19,5 +14,7 @@ jobs:
       - name: Release
         uses: google-github-actions/release-please-action@v3.7.3
         with:
+          # to create protected tags
+          token: ${{ secrets.RELEASE_PLEASE_GITHUB_TOKEN }}
           release-type: simple
           signoff: "Matthias Kay <matthias.kay@hlag.com>"

--- a/templates/default/.github/workflows/release.yml
+++ b/templates/default/.github/workflows/release.yml
@@ -7,11 +7,6 @@ on:
     branches:
       - main
 
-permissions:
-  # to create protected tags
-  contents: write
-  pull-requests: write
-
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -19,5 +14,7 @@ jobs:
       - name: Release
         uses: google-github-actions/release-please-action@v3.7.3
         with:
+          # to create protected tags
+          token: ${{ secrets.RELEASE_PLEASE_GITHUB_TOKEN }}
           release-type: simple
           signoff: "Matthias Kay <matthias.kay@hlag.com>"


### PR DESCRIPTION
# Description

Use a personal access token to allow Release-Please to create protected tags. `GITHUB_TOKEN` does not work.

# Verification

None

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
