### PR TITLE
feat: use the `AWS_REGION` from secrets for TfLint

### DIFF
--- a/templates/terraform-module/.github/workflows/terraform.yml
+++ b/templates/terraform-module/.github/workflows/terraform.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_TFLINT_ROLE_ARN }}
           role-session-name: tflint
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: install tflint
         run: |


### PR DESCRIPTION
# Description

`AWS_REGION` is stored as secret as variables are not support by `integrations/github` provider.

# Verification

None

# Checklist

- [X] My code follows the style guidelines of the project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
