### PR TITLE
ci: run auto-approval for Renovate PRs

### DIFF
--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: github.actor == 'kayman-mk'
+    if: github.actor == 'renovate[bot]'
     steps:
       # yamllint disable-line rule:comments
       - uses: hmarr/auto-approve-action@de8ae18c173c131e182d4adf2c874d8d2308a85b # v3.1.0
+        with:
+          review-message: "Auto approved automated PR"


### PR DESCRIPTION
Renovate PRs are created by `renovate[bot]`. So use the correct user id here to approve these PRs.