### PR TITLE
ci: use correct user id to identify Renovate pull requests for auto-approval

### DIFF
--- a/templates/default/.github/workflows/renvovate-auto-approve.yml
+++ b/templates/default/.github/workflows/renvovate-auto-approve.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: github.actor == 'kayman-mk'
+    if: github.actor == 'renovate[bot]'
     steps:
       # yamllint disable-line rule:comments
       - uses: hmarr/auto-approve-action@de8ae18c173c131e182d4adf2c874d8d2308a85b # v3.1.0
+        with:
+          review-message: "Auto approved automated PR"


### PR DESCRIPTION
The PRs are now created by `renovate[bot]` user. So we better check for this user id and auto-approve these pull requests.