### PR TITLE
chore: use PAT to auto-approve Renovate PRs

### DIFF
--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
     if: github.actor == 'renovate[bot]'
     steps:
-      # yamllint disable-line rule:comments
-      - uses: hmarr/auto-approve-action@44888193675f29a83e04faf4002fa8c0b537b1e4 # v3.2.1
+      - uses: hmarr/auto-approve-action@44888193675f29a83e04faf4002fa8c0b537b1e4  # v3.2.1
         with:
-          review-message: "Auto approved automated PR"
+          review-message: "Auto approved Renovate PR by organization"
+          github-token: ${{ secrets.PAT_FOR_PR_AUTO_APPROVAL }}

--- a/templates/default/.github/workflows/renvovate-auto-approve.yml
+++ b/templates/default/.github/workflows/renvovate-auto-approve.yml
@@ -11,7 +11,8 @@ jobs:
       pull-requests: write
     if: github.actor == 'renovate[bot]'
     steps:
-      # yamllint disable-line rule:comments
+      # xyamllint disable-line rule:comments
       - uses: hmarr/auto-approve-action@44888193675f29a83e04faf4002fa8c0b537b1e4 # v3.2.1
         with:
-          review-message: "Auto approved automated PR"
+          review-message: "Auto approved Renovate PR by organization"
+          github-token: ${{ secrets.PAT_FOR_PR_AUTO_APPROVAL }}

--- a/templates/default/.github/workflows/renvovate-auto-approve.yml
+++ b/templates/default/.github/workflows/renvovate-auto-approve.yml
@@ -11,8 +11,7 @@ jobs:
       pull-requests: write
     if: github.actor == 'renovate[bot]'
     steps:
-      # xyamllint disable-line rule:comments
-      - uses: hmarr/auto-approve-action@44888193675f29a83e04faf4002fa8c0b537b1e4 # v3.2.1
+      - uses: hmarr/auto-approve-action@44888193675f29a83e04faf4002fa8c0b537b1e4  # v3.2.1
         with:
           review-message: "Auto approved Renovate PR by organization"
           github-token: ${{ secrets.PAT_FOR_PR_AUTO_APPROVAL }}


### PR DESCRIPTION
Uses the new PAT `secrets.PAT_FOR_PR_AUTO_APPROVAL` to approve Renovate PRs. Temporary created access tokens via GitHub App do not work here as the app is not a valid approver.

To use the auto-merge feature, make sure that the owner of the PAT is in the list of approvers.