### PR TITLE
fix: do not check for a specific comment indentation in YAML files

### DIFF
--- a/.config/yamllint.yml
+++ b/.config/yamllint.yml
@@ -4,3 +4,5 @@ extends: default
 rules:
   line-length:
     max: 132
+  comments:
+    min-spaces-from-content: 1

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,7 +9,6 @@ jobs:
   find-changes:
     runs-on: ubuntu-latest
     steps:
-      # yamllint disable-line rule:comments
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: changes
         with:
@@ -49,7 +48,6 @@ jobs:
     if: needs.find-changes.outputs.json == 'true'
     needs: find-changes
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Run JSON Lint
@@ -61,7 +59,6 @@ jobs:
     if: needs.find-changes.outputs.markdown == 'true'
     needs: find-changes
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Validate Markdown file
@@ -75,10 +72,8 @@ jobs:
     if: needs.find-changes.outputs.renovate-config == 'true'
     needs: find-changes
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      # yamllint disable-line rule:comments
       - uses: suzuki-shunsuke/github-action-renovate-config-validator@b7cd2b598bb51d071a2474e98f55cc25f91abec1 # v0.1.3
 
   lint-workflow:
@@ -90,7 +85,6 @@ jobs:
       image: rhysd/actionlint:1.6.26@sha256:2362769b1d75056da70e7af1b12d9e52746f3a123b8f22a4322869e8f2cd45f2
       options: --cpus 1 --user root
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Validate Github workflows
@@ -107,7 +101,6 @@ jobs:
       image: rhysd/actionlint:1.6.26@sha256:2362769b1d75056da70e7af1b12d9e52746f3a123b8f22a4322869e8f2cd45f2
       options: --cpus 1 --user root
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Validate Github workflow templates
@@ -124,11 +117,9 @@ jobs:
     needs: find-changes
     if: needs.find-changes.outputs.yaml == 'true'
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: yaml-lint
-        # yamllint disable-line rule:comments
         uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3.1.1
         with:
           config_file: .config/yamllint.yml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,7 +16,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      # yamllint disable-line rule:comments
       - uses: amannn/action-semantic-pull-request@e9fabac35e210fea40ca5b14c0da95a099eff26f # v5.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/slash-ops-command-help.yml
+++ b/.github/workflows/slash-ops-command-help.yml
@@ -12,7 +12,6 @@ jobs:
     name: "ChatOps: /help"
     runs-on: ubuntu-latest
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Choose maintainer
@@ -22,7 +21,6 @@ jobs:
           echo "maintainer=$maintainer" >> "$GITHUB_OUTPUT"
 
       - name: Create comment
-        # yamllint disable-line rule:comments
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           # yamllint disable rule:line-length

--- a/.github/workflows/slash-ops-comment-dispatch.yml
+++ b/.github/workflows/slash-ops-comment-dispatch.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Slash Command Dispatch
-        # yamllint disable-line rule:comments
         uses: peter-evans/slash-command-dispatch@a28ee6cd74d5200f99e247ebc7b365c03ae0ef3c # v3.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -1,5 +1,5 @@
 ---
-name: 'Check spelling'
+name: "Check spelling"
 
 # yamllint disable-line rule:truthy
 on:
@@ -9,10 +9,8 @@ jobs:
   cspell:
     runs-on: ubuntu-latest
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      # yamllint disable-line rule:comments
       - uses: streetsidesoftware/cspell-action@6043e383e6abacdc8b8a0d97756586da8d0d985d # v5.1.0
         with:
           config: .config/cspell.json

--- a/.github/workflows/welcome-message.yml
+++ b/.github/workflows/welcome-message.yml
@@ -13,7 +13,6 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           # yamllint disable rule:line-length

--- a/templates/default/.config/yamllint.yml
+++ b/templates/default/.config/yamllint.yml
@@ -4,3 +4,5 @@ extends: default
 rules:
   line-length:
     max: 132
+  comments:
+    min-spaces-from-content: 1

--- a/templates/default/.github/workflows/linter.yml
+++ b/templates/default/.github/workflows/linter.yml
@@ -9,7 +9,6 @@ jobs:
   find-changes:
     runs-on: ubuntu-latest
     steps:
-      # yamllint disable-line rule:comments
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: changes
         with:
@@ -44,7 +43,6 @@ jobs:
     if: needs.find-changes.outputs.json == 'true'
     needs: find-changes
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Run JSON Lint
@@ -56,7 +54,6 @@ jobs:
     if: needs.find-changes.outputs.markdown == 'true'
     needs: find-changes
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Validate Markdown file
@@ -70,21 +67,17 @@ jobs:
     if: needs.find-changes.outputs.renovate-config == 'true'
     needs: find-changes
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      # yamllint disable-line rule:comments
       - uses: suzuki-shunsuke/github-action-renovate-config-validator@b7cd2b598bb51d071a2474e98f55cc25f91abec1 # v0.1.3
 
   lint-shell:
     name: Check shell scripts
     runs-on: ubuntu-latest
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: ShellCheck
-        # yamllint disable-line rule:comments
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
 
   lint-workflow:
@@ -96,7 +89,6 @@ jobs:
       image: rhysd/actionlint:1.6.26@sha256:2362769b1d75056da70e7af1b12d9e52746f3a123b8f22a4322869e8f2cd45f2
       options: --cpus 1 --user root
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Validate Github workflows
@@ -110,11 +102,9 @@ jobs:
     needs: find-changes
     if: needs.find-changes.outputs.yaml == 'true'
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: yaml-lint
-        # yamllint disable-line rule:comments
         uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3.1.1
         with:
           config_file: .config/yamllint.yml

--- a/templates/default/.github/workflows/pull-request.yml
+++ b/templates/default/.github/workflows/pull-request.yml
@@ -16,7 +16,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      # yamllint disable-line rule:comments
       - uses: amannn/action-semantic-pull-request@e9fabac35e210fea40ca5b14c0da95a099eff26f # v5.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/default/.github/workflows/slash-ops-command-help.yml
+++ b/templates/default/.github/workflows/slash-ops-command-help.yml
@@ -12,7 +12,6 @@ jobs:
     name: "ChatOps: /help"
     runs-on: ubuntu-latest
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Choose maintainer
@@ -22,7 +21,6 @@ jobs:
           echo "maintainer=$maintainer" >> "$GITHUB_OUTPUT"
 
       - name: Create comment
-        # yamllint disable-line rule:comments
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           # yamllint disable rule:line-length

--- a/templates/default/.github/workflows/slash-ops-comment-dispatch.yml
+++ b/templates/default/.github/workflows/slash-ops-comment-dispatch.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Slash Command Dispatch
-        # yamllint disable-line rule:comments
         uses: peter-evans/slash-command-dispatch@a28ee6cd74d5200f99e247ebc7b365c03ae0ef3c # v3.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/default/.github/workflows/spelling.yml
+++ b/templates/default/.github/workflows/spelling.yml
@@ -9,10 +9,8 @@ jobs:
   cspell:
     runs-on: ubuntu-latest
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      # yamllint disable-line rule:comments
       - uses: streetsidesoftware/cspell-action@6043e383e6abacdc8b8a0d97756586da8d0d985d # v5.1.0
         with:
           config: .config/cspell.json

--- a/templates/default/.github/workflows/stale.yml
+++ b/templates/default/.github/workflows/stale.yml
@@ -10,7 +10,6 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
           # yamllint disable rule:line-length

--- a/templates/default/.github/workflows/welcome-message.yml
+++ b/templates/default/.github/workflows/welcome-message.yml
@@ -13,7 +13,6 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           # yamllint disable rule:line-length

--- a/templates/terraform-module/.github/workflows/terraform-tfsec.yml
+++ b/templates/terraform-module/.github/workflows/terraform-tfsec.yml
@@ -18,17 +18,14 @@ jobs:
 
     steps:
       - name: Clone repo
-        # yamllint disable-line rule:comments
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Run tfsec
-        # yamllint disable-line rule:comments
         uses: tfsec/tfsec-sarif-action@21ded20e8ca120cd9d3d6ab04ef746477542a608 # v0.1.4
         with:
           sarif_file: tfsec.sarif
 
       - name: Upload SARIF file
-        # yamllint disable-line rule:comments
         uses: github/codeql-action/upload-sarif@c0d1daa7f7e14667747d73a7dbbe8c074bc8bfe2 # v2.22.9
         with:
           # Path to SARIF file relative to the root of the repository

--- a/templates/terraform-module/.github/workflows/terraform.yml
+++ b/templates/terraform-module/.github/workflows/terraform.yml
@@ -21,10 +21,8 @@ jobs:
       run:
         working-directory: ${{ matrix.directories }}
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      # yamllint disable-line rule:comments
       - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
         with:
           terraform_version: ${{ matrix.terraform }}
@@ -38,10 +36,8 @@ jobs:
   tflint:
     runs-on: ubuntu-latest
     steps:
-      # yamllint disable-line rule:comments
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      # yamllint disable-line rule:comments
       - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         name: Cache plugin dir
         with:
@@ -49,7 +45,6 @@ jobs:
           key: tflint-${{ hashFiles('.config/tflint.hcl') }}
 
       - name: configure aws credentials
-        # yamllint disable-line rule:comments
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
           role-to-assume: ${{ secrets.AWS_TFLINT_ROLE_ARN }}


### PR DESCRIPTION
The global default is 2 spaces. But Renovate uses only one and Prettier does the same. So instead of placing ignore rules everywhere, we relax the check. And there is no rule in the YAML specification at all.