### PR TITLE
ci: reference correct commit SHA in workflows

### DIFF
--- a/.github/workflows/this_linter.yml
+++ b/.github/workflows/this_linter.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   default:
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_linter_callable.yml@3a102f6e2e5326bde1f4b3ad8b9b4354323aef41
+    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_linter_callable.yml@e87de55f19cc1e069426c42120094e7e2446dad4
     secrets: inherit

--- a/.github/workflows/this_pull_request.yml
+++ b/.github/workflows/this_pull_request.yml
@@ -14,5 +14,5 @@ on:
 jobs:
   default:
     # yamllint disable-line rule:line-length
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_pull_request_callable.yml@3a102f6e2e5326bde1f4b3ad8b9b4354323aef41
+    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_pull_request_callable.yml@e87de55f19cc1e069426c42120094e7e2446dad4
     secrets: inherit

--- a/.github/workflows/this_release.yml
+++ b/.github/workflows/this_release.yml
@@ -9,5 +9,5 @@ on:
 
 jobs:
   default:
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_release_callable.yml@3a102f6e2e5326bde1f4b3ad8b9b4354323aef41
+    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_release_callable.yml@e87de55f19cc1e069426c42120094e7e2446dad4
     secrets: inherit

--- a/.github/workflows/this_release_dry_run.yml
+++ b/.github/workflows/this_release_dry_run.yml
@@ -10,5 +10,5 @@ on:
 jobs:
   default:
     # yamllint disable-line rule:line-length
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_release_dry_run_callable.yml@3a102f6e2e5326bde1f4b3ad8b9b4354323aef41
+    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_release_dry_run_callable.yml@e87de55f19cc1e069426c42120094e7e2446dad4
     secrets: inherit

--- a/.github/workflows/this_renovate_auto_approve.yml
+++ b/.github/workflows/this_renovate_auto_approve.yml
@@ -7,5 +7,5 @@ on: pull_request_target
 jobs:
   default:
     # yamllint disable-line rule:line-length
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_renovate_auto_approve_callable.yml@3a102f6e2e5326bde1f4b3ad8b9b4354323aef41
+    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_renovate_auto_approve_callable.yml@e87de55f19cc1e069426c42120094e7e2446dad4
     secrets: inherit

--- a/.github/workflows/this_slash_ops_command_help.yml
+++ b/.github/workflows/this_slash_ops_command_help.yml
@@ -10,5 +10,5 @@ on:
 jobs:
   default:
     # yamllint disable-line rule:line-length
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_slash_ops_command_help_callable.yml@3a102f6e2e5326bde1f4b3ad8b9b4354323aef41
+    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_slash_ops_command_help_callable.yml@e87de55f19cc1e069426c42120094e7e2446dad4
     secrets: inherit

--- a/.github/workflows/this_slash_ops_comment_dispatch.yml
+++ b/.github/workflows/this_slash_ops_comment_dispatch.yml
@@ -10,5 +10,5 @@ on:
 jobs:
   default:
     # yamllint disable-line rule:line-length
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_slash_ops_comment_dispatch_callable.yml@3a102f6e2e5326bde1f4b3ad8b9b4354323aef41
+    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_slash_ops_comment_dispatch_callable.yml@e87de55f19cc1e069426c42120094e7e2446dad4
     secrets: inherit

--- a/.github/workflows/this_spelling.yml
+++ b/.github/workflows/this_spelling.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   default:
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_spelling_callable.yml@3a102f6e2e5326bde1f4b3ad8b9b4354323aef41
+    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_spelling_callable.yml@e87de55f19cc1e069426c42120094e7e2446dad4
     secrets: inherit

--- a/.github/workflows/this_stale.yml
+++ b/.github/workflows/this_stale.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   default:
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_stale_callable.yml@3a102f6e2e5326bde1f4b3ad8b9b4354323aef41
+    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_stale_callable.yml@e87de55f19cc1e069426c42120094e7e2446dad4
     secrets: inherit

--- a/.github/workflows/this_welcome_message.yml
+++ b/.github/workflows/this_welcome_message.yml
@@ -10,5 +10,5 @@ on:
 jobs:
   default:
     # yamllint disable-line rule:line-length
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_welcome_message_callable.yml@3a102f6e2e5326bde1f4b3ad8b9b4354323aef41
+    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_welcome_message_callable.yml@e87de55f19cc1e069426c42120094e7e2446dad4
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ on:
 
 jobs:
   default:
-    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_linter_callable.yml@3a102f6e2e5326bde1f4b3ad8b9b4354323aef41
+    uses: Hapag-Lloyd/Repository-Templates/.github/workflows/default_linter_callable.yml@e87de55f19cc1e069426c42120094e7e2446dad4
     secrets: inherit
 ```
 


### PR DESCRIPTION
As we are squashing the feature branches, we weren't able to reference a valid commit in #124. This is fixed in this PR, referencing the commit which was created by #124.